### PR TITLE
Update build.xml to allow for jar compilation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -48,5 +48,13 @@
             </batchtest>
         </junit>
     </target>
+    
+    <target name="jar">
+        <mkdir dir="build/jar"/>
+        <jar destfile="build/jar/GrahamScan.jar" basedir="build/main">
+            <fileset file= "README.md"/>
+            <fileset file= "LICENSE.txt"/>
+        </jar>
+    </target>
 
 </project>


### PR DESCRIPTION
Added the jar target in the build.xml, so that the project may be packaged for use. Includes README, and license for license compliance.